### PR TITLE
Deleted placeholder message

### DIFF
--- a/src/lib/ToolsView.svelte
+++ b/src/lib/ToolsView.svelte
@@ -61,7 +61,7 @@
 	{#if events.length > 0}
 		<EventGrid {events} category={null} {openEvent} onComplete={handleComplete} isLoggedIn={!!user} />
 	{:else}
-		<p class="placeholder-text">No tools available yet.</p>
+		<p class="placeholder-text"></p>
 	{/if}
 	<p class="description">Useful tools and resources for running your club.</p>
 


### PR DESCRIPTION
I deleted the placeholder message from the Leaders' Toolbox saying "No tools available yet." The Create Your Own YSWS tool is usable now, so this message was confusing and outdated.